### PR TITLE
Use alarm_cluster dimension to define the Nagios host ownership

### DIFF
--- a/_modules/nagios_alarming.py
+++ b/_modules/nagios_alarming.py
@@ -73,3 +73,15 @@ def threshold(alarm, triggers, delay=10):
                     window = int(rule.get('window'))
 
     return window + delay
+
+
+def alarm_cluster_hostname(dimension_key, alarm, default_hostname):
+    """
+    Return the associated Nagios host_name of an alarm_cluster.
+    """
+
+    for key, value in alarm.get('dimension', {}).items():
+        if key == dimension_key:
+            return value
+
+    return default_hostname

--- a/metadata/service/server/single.yml
+++ b/metadata/service/server/single.yml
@@ -12,6 +12,8 @@ parameters:
     nagios_status_port: 8001
     nagios_notification_smtp_server: 127.0.0.1
     nagios_notification_from: nagios@localhost
+    nagios_alarm_cluster_default_host: 00-clusters
+    nagios_host_dimension_key: nagios_host
   nagios:
     server:
       enabled: true
@@ -45,3 +47,29 @@ parameters:
           from: ${_param:nagios_notification_from}
           host_command_name: notify-host-by-smtp
           service_command_name: notify-service-by-smtp
+      dynamic:
+        enabled: true
+        grain_hostname: 'host'
+        hostgroups:
+          - target: '*'
+            name: All
+            expr_from: glob
+        hosts:
+          - target: '*'
+            expr_from: glob
+            contact_groups: Operator
+            use: generic_host_tpl
+            interface:
+            - eth0
+            - ens3
+        services:
+          - target: '*'
+            expr_from: glob
+            name: SSH
+            check_command: check_ssh
+        stacklight_alarms:
+          enabled: true
+        stacklight_alarm_clusters:
+          enabled: true
+          dimension_key: ${_param:nagios_host_dimension_key}
+          default_host: ${_param:nagios_alarm_cluster_default_host}

--- a/nagios/files/hosts.cfg
+++ b/nagios/files/hosts.cfg
@@ -41,7 +41,7 @@ define host {
   passive_checks_enabled {{ host.get('passive_checks_enabled', default_host.passive_checks_enabled) }}
 {# Extra properties -#}
 {%- for propertie, value in host.items() -%}
-  {%- if propertie not in default_host.keys() and propertie not in ['use', 'register', 'name', 'host_name', 'alias', 'display_name', 'address', 'contacts', 'contact_groups', 'target', 'interface'] %}
+  {%- if propertie not in default_host.keys() and propertie not in ['use', 'register', 'name', 'host_name', 'alias', 'display_name', 'address', 'contacts', 'contact_groups', 'target', 'expr_from', 'interface'] %}
   {{ propertie }} {{value}}
   {%- endif -%}
 {% endfor %}
@@ -58,7 +58,7 @@ define host {
   address {{ host.address }}
 {# Extra properties -#}
 {%- for propertie, value in host.items() -%}
-  {%- if propertie not in ['use', 'register', 'host_name', 'name', 'alias', 'display_name', 'address', 'contacts', 'contact_groups', 'target', 'interface'] %}
+  {%- if propertie not in ['use', 'register', 'host_name', 'name', 'alias', 'display_name', 'address', 'contacts', 'contact_groups', 'target', 'expr_from', 'interface'] %}
   {{ propertie }} {{value}}
   {%- endif -%}
 {% endfor %}

--- a/nagios/files/services.cfg
+++ b/nagios/files/services.cfg
@@ -54,7 +54,7 @@ define service {
   notification_options {{ service.get('notification_options', default_service.notification_options ) }}
 {#- Extra properties -#}
 {%- for propertie, value in service.items() -%}
-  {%- if propertie not in default_service.keys() and propertie not in ['use', 'register', 'name', 'service_description', 'host_name', 'contacts', 'contact_groups', 'check_command', 'target'] %}
+  {%- if propertie not in default_service.keys() and propertie not in ['use', 'register', 'name', 'service_description', 'host_name', 'contacts', 'contact_groups', 'check_command', 'target', 'expr_from'] %}
   {{ propertie }} {{value}}
   {%- endif -%}
 {% endfor %}
@@ -70,7 +70,7 @@ define service {
   check_command {{ service.check_command }}
 {#- Extra properties -#}
 {%- for propertie, value in service.items() -%}
-  {%- if propertie not in ['use', 'register', 'service_description', 'host_name', 'contacts', 'contact_groups', 'check_command', 'target', 'name'] %}
+  {%- if propertie not in ['use', 'register', 'service_description', 'host_name', 'contacts', 'contact_groups', 'check_command', 'target', 'expr_from', 'name'] %}
   {{ propertie }} {{value}}
   {%- endif -%}
 {% endfor %}


### PR DESCRIPTION
The heka nagios encoder for GSE must be adapted to use the 'domain_key'.
Also, all alarm_cluster defined in service formulas support metadata must be updated to add the dimension. 