### PR TITLE
Support LDAP authentication and authorization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,29 @@ Nagios UI configrations with HTTP basic authentication
             username: nagiosadmin
             password: secret
 
+Nagios UI configrations with LDAP authentication/authorization:
+
+
+.. code-block:: yaml
+
+    nagios:
+      server:
+        enabled: true
+        ui:
+          enabled: true
+          basic_auth:
+            username: nagiosadmin
+            password: secret
+          ldap_authnz:
+            # Url format is described here
+            # http://httpd.apache.org/docs/2.0/mod/mod_auth_ldap.html#authldapurl
+            url: ldaps://ldap.domain.ltd:<port>/cn=users,dc=domain,dc=local?uid?sub?<filter>
+            bind_dn: cn=admin,dc=domain,dc=local
+            bind_password: secret
+            # Optionaly, restrict access to members of a group:
+            ldap_group_dn: cn=admins,ou=groups,dc=domain,dc=local
+            ldap_group_attribute: memberUid
+
 The formula configures commands to send notifications by SMTP.
 The authentifcation is disabled by default.
 Authentication methods supported is either 'plain', 'login' or 'CRAMMD5'.

--- a/README.rst
+++ b/README.rst
@@ -45,11 +45,12 @@ Nagios UI configrations with HTTP basic authentication
         enabled: true
         ui:
           enabled: true
-          basic_auth:
-            username: nagiosadmin
-            password: secret
+          auth:
+            basic:
+              username: nagiosadmin
+              password: secret
 
-Nagios UI configrations with LDAP authentication/authorization:
+Nagios UI configuration with LDAP authentication/authorization:
 
 
 .. code-block:: yaml
@@ -59,18 +60,20 @@ Nagios UI configrations with LDAP authentication/authorization:
         enabled: true
         ui:
           enabled: true
-          basic_auth:
-            username: nagiosadmin
-            password: secret
-          ldap_authnz:
-            # Url format is described here
-            # http://httpd.apache.org/docs/2.0/mod/mod_auth_ldap.html#authldapurl
-            url: ldaps://ldap.domain.ltd:<port>/cn=users,dc=domain,dc=local?uid?sub?<filter>
-            bind_dn: cn=admin,dc=domain,dc=local
-            bind_password: secret
-            # Optionaly, restrict access to members of a group:
-            ldap_group_dn: cn=admins,ou=groups,dc=domain,dc=local
-            ldap_group_attribute: memberUid
+          auth:
+            basic:
+              username: nagiosadmin
+              password: secret
+            ldap:
+              enabled: true
+              # Url format is described here
+              # http://httpd.apache.org/docs/2.0/mod/mod_auth_ldap.html#authldapurl
+              url: ldaps://ldap.domain.ltd:<port>/cn=users,dc=domain,dc=local?uid?sub?<filter>
+              bind_dn: cn=admin,dc=domain,dc=local
+              bind_password: secret
+              # Optionaly, restrict access to members of a group:
+              ldap_group_dn: cn=admins,ou=groups,dc=domain,dc=local
+              ldap_group_attribute: memberUid
 
 The formula configures commands to send notifications by SMTP.
 The authentifcation is disabled by default.

--- a/metadata/service/server/init.yml
+++ b/metadata/service/server/init.yml
@@ -36,9 +36,10 @@ parameters:
         enabled: true
         bind: ${_param:nagios_ui_bind}
         port: ${_param:nagios_ui_port}
-        basic_auth:
-          username: ${_param:nagios_password}
-          password: ${_param:nagios_username}
+        auth:
+          basic:
+            username: ${_param:nagios_password}
+            password: ${_param:nagios_username}
         wsgi:
           bind: ${_param:nagios_status_bind}
           port: ${_param:nagios_status_port}

--- a/nagios/files/cgi.cfg
+++ b/nagios/files/cgi.cfg
@@ -114,10 +114,10 @@ use_ssl_authentication=0
  
 #default_user_name=guest
 
-{%- if server.ui.get('ldap_authnz') is mapping and server.ui.ldap_authnz.url is defined %}
+{%- if server.ui.auth.ldap.enabled %}
 {% set username = '*' %}
 {%- else %}
-{% set username = server.ui.basic_auth.username %}
+{% set username = server.ui.auth.basic.username %}
 {%- endif %}
 # SYSTEM/PROCESS INFORMATION ACCESS
 # This option is a comma-delimited list of all usernames that

--- a/nagios/files/cgi.cfg
+++ b/nagios/files/cgi.cfg
@@ -114,8 +114,11 @@ use_ssl_authentication=0
  
 #default_user_name=guest
 
-
-
+{%- if server.ui.get('ldap_authnz') is mapping and server.ui.ldap_authnz.url is defined %}
+{% set username = '*' %}
+{%- else %}
+{% set username = server.ui.basic_auth.username %}
+{%- endif %}
 # SYSTEM/PROCESS INFORMATION ACCESS
 # This option is a comma-delimited list of all usernames that
 # have access to viewing the Nagios process information as
@@ -124,7 +127,7 @@ use_ssl_authentication=0
 # not use authorization.  You may use an asterisk (*) to
 # authorize any user who has authenticated to the web server.
 
-authorized_for_system_information={{ server.ui.basic_auth.username }}
+authorized_for_system_information={{ username }}
 
 
 
@@ -136,7 +139,7 @@ authorized_for_system_information={{ server.ui.basic_auth.username }}
 # an asterisk (*) to authorize any user who has authenticated
 # to the web server.
 
-authorized_for_configuration_information={{ server.ui.basic_auth.username }}
+authorized_for_configuration_information={{ username }}
 
 
 
@@ -149,7 +152,7 @@ authorized_for_configuration_information={{ server.ui.basic_auth.username }}
 # You may use an asterisk (*) to authorize any user who has
 # authenticated to the web server.
 
-authorized_for_system_commands={{ server.ui.basic_auth.username }}
+authorized_for_system_commands={{ username }}
 
 
 
@@ -162,8 +165,8 @@ authorized_for_system_commands={{ server.ui.basic_auth.username }}
 # to authorize any user who has authenticated to the web server.
 
 
-authorized_for_all_services={{ server.ui.basic_auth.username }}
-authorized_for_all_hosts={{ server.ui.basic_auth.username }}
+authorized_for_all_services={{ username }}
+authorized_for_all_hosts={{ username }}
 
 
 
@@ -176,8 +179,8 @@ authorized_for_all_hosts={{ server.ui.basic_auth.username }}
 # authorization).  You may use an asterisk (*) to authorize any
 # user who has authenticated to the web server.
 
-authorized_for_all_service_commands={{ server.ui.basic_auth.username }}
-authorized_for_all_host_commands={{ server.ui.basic_auth.username }}
+authorized_for_all_service_commands={{ username }}
+authorized_for_all_host_commands={{ username }}
 
 
 

--- a/nagios/files/nagios.conf.Debian
+++ b/nagios/files/nagios.conf.Debian
@@ -26,7 +26,25 @@
     AuthName "Nagios Access"
     AuthType Basic
     AuthUserFile {{ server.ui.htpasswd_file }}
+    {%- if server.ui.get('ldap_authnz') is mapping and server.ui.ldap_authnz.url is defined %}
+    AuthBasicProvider file ldap
+    AuthLDAPURL "{{ server.ui.ldap_authnz.url }}"
+    AuthLDAPBindDN "{{ server.ui.ldap_authnz.bind_dn }}"
+    AuthLDAPBindPassword "{{ server.ui.ldap_authnz.bind_password }}"
+      {%- if server.ui.ldap_authnz.ldap_group_dn is defined %}
+    AuthLDAPGroupAttribute {{ server.ui.ldap_authnz.ldap_group_attribute }}
+    AuthLDAPGroupAttributeIsDN off
+    AuthBasicAuthoritative on
+    <RequireAny>
+    require user {{ server.ui.basic_auth.username }}
+    Require ldap-group {{ server.ui.ldap_authnz.ldap_group_dn }}
+    </RequireAny>
+      {%- else %}
     require valid-user
+      {%- endif %}
+    {%- else %}
+    require valid-user
+    {%- endif %}
   </DirectoryMatch>
 
   <Directory {{ server.ui.physical_html_path }}>

--- a/nagios/files/nagios.conf.Debian
+++ b/nagios/files/nagios.conf.Debian
@@ -26,18 +26,18 @@
     AuthName "Nagios Access"
     AuthType Basic
     AuthUserFile {{ server.ui.htpasswd_file }}
-    {%- if server.ui.get('ldap_authnz') is mapping and server.ui.ldap_authnz.url is defined %}
+    {%- if server.ui.auth.ldap.enabled %}
     AuthBasicProvider file ldap
-    AuthLDAPURL "{{ server.ui.ldap_authnz.url }}"
-    AuthLDAPBindDN "{{ server.ui.ldap_authnz.bind_dn }}"
-    AuthLDAPBindPassword "{{ server.ui.ldap_authnz.bind_password }}"
-      {%- if server.ui.ldap_authnz.ldap_group_dn is defined %}
-    AuthLDAPGroupAttribute {{ server.ui.ldap_authnz.ldap_group_attribute }}
+    AuthLDAPURL "{{ server.ui.auth.ldap.url }}"
+    AuthLDAPBindDN "{{ server.ui.auth.ldap.bind_dn }}"
+    AuthLDAPBindPassword "{{ server.ui.auth.ldap.bind_password }}"
+      {%- if server.ui.auth.ldap.ldap_group_dn is defined %}
+    AuthLDAPGroupAttribute {{ server.ui.auth.ldap.ldap_group_attribute }}
     AuthLDAPGroupAttributeIsDN off
     AuthBasicAuthoritative on
     <RequireAny>
-    require user {{ server.ui.basic_auth.username }}
-    Require ldap-group {{ server.ui.ldap_authnz.ldap_group_dn }}
+    require user {{ server.ui.auth.basic.username }}
+    Require ldap-group {{ server.ui.auth.ldap.ldap_group_dn }}
     </RequireAny>
       {%- else %}
     require valid-user

--- a/nagios/map.jinja
+++ b/nagios/map.jinja
@@ -36,9 +36,14 @@
           'apache_config': '/etc/nagios3/apache2.conf',
           'apache_log_dir': '/var/log/apache2',
           'nagios_check_command': '/usr/lib/nagios/plugins/check_nagios /var/cache/nagios3/status.dat 5 \'/usr/sbin/nagios3\'',
-          'basic_auth': {
-            'username': 'nagiosadmin',
-            'password': 'nagios',
+          'auth': {
+            'basic': {
+              'username': 'nagiosadmin',
+              'password': 'nagios',
+            },
+            'ldap': {
+              'enabled': False,
+            },
           },
           'wsgi': {
             'script_path': '/usr/local/bin/nagios-process-service-checks.wsgi',
@@ -102,9 +107,14 @@
           'apache_config': '/etc/nagios/apache2.conf',
           'apache_log_dir': '/var/log/httpd',
           'nagios_check_command': '/usr/lib64/nagios/plugins/check_nagios -F /var/log/nagios/status.dat -e 5 -C /usr/sbin/nagios',
-          'basic_auth': {
-            'username': 'nagiosadmin',
-            'password': 'nagios',
+          'auth': {
+            'basic': {
+              'username': 'nagiosadmin',
+              'password': 'nagios',
+            },
+            'ldap': {
+              'enabled': False,
+            },
           },
           'wsgi': {
             'script_path': '/usr/local/bin/nagios-process-service-checks.wsgi',

--- a/nagios/server.sls
+++ b/nagios/server.sls
@@ -109,6 +109,16 @@ wsgi_pkg:
     - watch_in:
       - service: {{ server.ui.apache_service }}
 
+{%- if server.ui.get('ldap_authnz') is mapping and server.ui.ldap_authnz.url is defined %}
+{% for mod in ('ldap', 'authnz_ldap') %}
+enable_apache_{{ mod }}_module:
+  apache_module.enable:
+    - name: {{ mod }}
+    - watch_in:
+      - service: {{ server.ui.apache_service }}
+{% endfor %}
+{%- endif %}
+
 enable_apache_wsgi_module:
   apache_module.enable:
     - name: wsgi

--- a/nagios/server.sls
+++ b/nagios/server.sls
@@ -28,11 +28,11 @@ nagios-cgi-server-package:
     - name: {{ server.ui.package}}
 {% endif %}
 
-{% if server.ui.basic_auth is defined and server.ui.basic_auth.password is defined %}
+{% if server.ui.auth.basic is defined and server.ui.auth.basic.password is defined %}
 nagios-cgi-username:
   webutil.user_exists:
-    - name: {{ server.ui.basic_auth.get('username', 'nagiosadmin') }}
-    - password: {{ server.ui.basic_auth.password }}
+    - name: {{ server.ui.auth.basic.get('username', 'nagiosadmin') }}
+    - password: {{ server.ui.auth.basic.password }}
     - htpasswd_file: {{ server.ui.htpasswd_file }}
     - options: d
     - force: true
@@ -109,7 +109,7 @@ wsgi_pkg:
     - watch_in:
       - service: {{ server.ui.apache_service }}
 
-{%- if server.ui.get('ldap_authnz') is mapping and server.ui.ldap_authnz.url is defined %}
+{%- if server.ui.auth.ldap.enabled %}
 {% for mod in ('ldap', 'authnz_ldap') %}
 enable_apache_{{ mod }}_module:
   apache_module.enable:


### PR DESCRIPTION
Can be tested by installing OpenLdap with the StackLight script [0]  on node **cfg01** and with this user data (pillar) :

nagios:server:ui:ldap_authnz:

>   url: ldap://cfg01/dc=stacklight,dc=ci?uid?sub?(objectClass=*)
>   bind_dn: cn=admin,dc=stacklight,dc=ci 
>   bind_password: admin
>   ldap_group_dn: cn=plugin_admins,ou=groups,dc=stacklight,dc=ci
>   ldap_group_attribute: memberUid

[0] https://raw.githubusercontent.com/openstack/stacklight-integration-tests/master/fixtures/ldap/install_slapd.sh