### PR TITLE
Fix command path to support macro

### DIFF
--- a/nagios/files/commands.cfg
+++ b/nagios/files/commands.cfg
@@ -3,7 +3,7 @@
 
 {% for cmd_id, conf in commands.items() -%}
         define command {
-{%- if not conf.command_line[0] == '/' %}
+{%- if conf.command_line[0] not in ('/', '$') %}
           command_line {{server.plugin_dir }}/{{ conf.command_line }}
 {%- else %}
           command_line {{ conf.command_line }}


### PR DESCRIPTION
The command path can start with a Nagios macro (typically $USER1$).